### PR TITLE
fix: compatibility with new controller-runtime

### DIFF
--- a/applier/util.go
+++ b/applier/util.go
@@ -3,14 +3,14 @@ package applier
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 func ApplyManifestFile(inClusterConfig *rest.Config, filename string) error {
-	manifest, err := ioutil.ReadFile(filename)
+	manifest, err := os.ReadFile(filename)
 	if err != nil {
 		return fmt.Errorf("function ApplyManifestFile failed, unable to read %s file: %v", filename, err)
 	}
@@ -19,7 +19,11 @@ func ApplyManifestFile(inClusterConfig *rest.Config, filename string) error {
 }
 
 func ApplyManifest(inClusterConfig *rest.Config, manifest *[]byte) error {
-	restMapper, err := apiutil.NewDynamicRESTMapper(inClusterConfig)
+	httpClient, err := rest.HTTPClientFor(inClusterConfig)
+	if err != nil {
+		return fmt.Errorf("unable to initialize httpClient: %w", err)
+	}
+	restMapper, err := apiutil.NewDynamicRESTMapper(inClusterConfig, httpClient)
 	if err != nil {
 		return fmt.Errorf("unable to initialize NewDynamicRESTMapper")
 	}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"google.golang.org/grpc/credentials/insecure"
 	"net"
 	"os"
 	"sync"
 	"time"
+
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/loft-sh/vcluster-sdk/clienthelper"
 	"github.com/loft-sh/vcluster-sdk/hook"
@@ -150,7 +151,8 @@ func (m *manager) InitWithOptions(opts Options) (*synccontext.RegisterContext, e
 
 	log.Infof("Try creating context...")
 	var pluginContext *remote.Context
-	err := wait.PollUntilContextCancel(m.context.Context, time.Second*5, true, func(_ context.Context) (done bool, err error) {
+	ctx := context.Background()
+	err := wait.PollUntilContextCancel(ctx, time.Second*5, true, func(_ context.Context) (done bool, err error) {
 		conn, err := grpc.Dial(m.address, grpc.WithInsecure())
 		if err != nil {
 			return false, nil
@@ -242,7 +244,7 @@ func (m *manager) InitWithOptions(opts Options) (*synccontext.RegisterContext, e
 	}
 
 	m.context = &synccontext.RegisterContext{
-		Context:                context.Background(),
+		Context:                ctx,
 		Options:                virtualClusterOptions,
 		TargetNamespace:        pluginContext.TargetNamespace,
 		CurrentNamespace:       pluginContext.CurrentNamespace,

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -652,6 +652,10 @@ func newCurrentNamespaceClient(ctx context.Context, currentNamespace string, loc
 		currentNamespaceCache.WaitForCacheSync(ctx)
 	}
 
+	if opts.NewClient == nil {
+		opts.NewClient = client.New
+	}
+
 	// create a current namespace client
 	return opts.NewClient(localManager.GetConfig(), client.Options{
 		Scheme: localManager.GetScheme(),

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -27,6 +27,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
 const (
@@ -225,6 +226,7 @@ func (m *manager) InitWithOptions(opts Options) (*synccontext.RegisterContext, e
 		Cache: cache.Options{
 			DefaultNamespaces: map[string]cache.Config{virtualClusterOptions.TargetNamespace: {}},
 		},
+		Metrics: server.Options{BindAddress: "0"},
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "create phyiscal manager")
@@ -234,6 +236,7 @@ func (m *manager) InitWithOptions(opts Options) (*synccontext.RegisterContext, e
 		LeaderElection: false,
 		NewClient:      opts.NewClient,
 		NewCache:       opts.NewCache,
+		Metrics:        server.Options{BindAddress: "0"},
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "create virtual manager")

--- a/syncer/testing/manager.go
+++ b/syncer/testing/manager.go
@@ -2,16 +2,17 @@ package testing
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
-	"net/http"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -57,10 +58,12 @@ func (f *fakeManager) AddHealthzCheck(name string, check healthz.Checker) error 
 
 func (f *fakeManager) AddReadyzCheck(name string, check healthz.Checker) error { return nil }
 
-func (f *fakeManager) GetWebhookServer() *webhook.Server { return nil }
+func (f *fakeManager) GetWebhookServer() webhook.Server { return nil }
 
 func (f *fakeManager) GetLogger() logr.Logger { return logr.Logger{} }
 
-func (f *fakeManager) GetControllerOptions() v1alpha1.ControllerConfigurationSpec {
-	return v1alpha1.ControllerConfigurationSpec{}
+func (f *fakeManager) GetControllerOptions() config.Controller {
+	return config.Controller{}
 }
+
+func (f *fakeManager) GetHTTPClient() *http.Client { return nil }

--- a/translate/crd.go
+++ b/translate/crd.go
@@ -68,7 +68,7 @@ func EnsureCRDFromPhysicalCluster(ctx context.Context, pConfig *rest.Config, vCo
 
 	// wait for crd to become ready
 	log.NewWithoutName().Infof("Wait for crd %s to become ready in virtual cluster", groupVersionKind.String())
-	err = wait.ExponentialBackoffWithContext(ctx, wait.Backoff{Duration: time.Second, Factor: 1.5, Cap: time.Minute, Steps: math.MaxInt32}, func() (bool, error) {
+	err = wait.ExponentialBackoffWithContext(ctx, wait.Backoff{Duration: time.Second, Factor: 1.5, Cap: time.Minute, Steps: math.MaxInt32}, func(ctx context.Context) (bool, error) {
 		crdDefinition, err := vClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, groupVersionResource.GroupResource().String(), metav1.GetOptions{})
 		if err != nil {
 			return false, errors.Wrap(err, "retrieve crd in virtual cluster")
@@ -99,7 +99,7 @@ func EnsureCRDFromFile(ctx context.Context, config *rest.Config, crdFilePath str
 	}
 
 	log.NewWithoutName().Infof("Create crd %s in virtual cluster", groupVersionKind.String())
-	err = wait.ExponentialBackoffWithContext(ctx, wait.Backoff{Duration: time.Second, Factor: 1.5, Cap: 5 * time.Minute, Steps: math.MaxInt32}, func() (bool, error) {
+	err = wait.ExponentialBackoffWithContext(ctx, wait.Backoff{Duration: time.Second, Factor: 1.5, Cap: 5 * time.Minute, Steps: math.MaxInt32}, func(ctx context.Context) (bool, error) {
 		err := applier.ApplyManifestFile(config, crdFilePath)
 		if err != nil {
 			log.NewWithoutName().Infof("Failed to apply CRD %s from the manifest file %s: %v", groupVersionKind.String(), crdFilePath, err)
@@ -113,7 +113,7 @@ func EnsureCRDFromFile(ctx context.Context, config *rest.Config, crdFilePath str
 
 	var lastErr error
 	log.NewWithoutName().Infof("Wait for crd %s to become ready in virtual cluster", groupVersionKind.String())
-	err = wait.ExponentialBackoffWithContext(ctx, wait.Backoff{Duration: time.Second, Factor: 1.5, Cap: time.Minute, Steps: math.MaxInt32}, func() (bool, error) {
+	err = wait.ExponentialBackoffWithContext(ctx, wait.Backoff{Duration: time.Second, Factor: 1.5, Cap: time.Minute, Steps: math.MaxInt32}, func(ctx context.Context) (bool, error) {
 		var found bool
 		found, lastErr = KindExists(config, groupVersionKind)
 		return found, nil


### PR DESCRIPTION
A bit hard to know if everything works as it's supposed to as it lacks tests, but at least code that depends on `vcluster-sdk` is compiling now :smile: 